### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,6 +61,8 @@ jobs:
 
   push_to_registry:
     name: Push Docker image to Docker Hub
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/ds-jhartmann/steam-inventory-tracker/security/code-scanning/1](https://github.com/ds-jhartmann/steam-inventory-tracker/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the `push_to_registry` job in the workflow file. This block should specify the minimal permissions required for the job. Since the job does not use the `GITHUB_TOKEN` for any write operations, we can set `contents: read` as the permission. This ensures that the job has only read access to the repository contents, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
