### PR TITLE
Fix timespan validation in PriceService

### DIFF
--- a/src/main/java/com/hinderegger/steaminventorytracker/service/PriceService.java
+++ b/src/main/java/com/hinderegger/steaminventorytracker/service/PriceService.java
@@ -80,7 +80,7 @@ public class PriceService {
       throw new PriceHistoryException(message);
     }
 
-    if (timespan == 7 && actualTimeDifference > timespan) {
+    if (timespan == 7 && actualTimeDifference < timespan) {
       throw new PriceHistoryException(message);
     }
 


### PR DESCRIPTION
## Summary
- correct comparison for 7-day timespan in `PriceService`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68429a9c25e48326a8311e978183f8ee