### PR TITLE
Fix not-found message for getItemByName

### DIFF
--- a/src/main/java/com/hinderegger/steaminventorytracker/service/ItemService.java
+++ b/src/main/java/com/hinderegger/steaminventorytracker/service/ItemService.java
@@ -60,7 +60,9 @@ public class ItemService {
   public Item getItemByName(final String name) {
     final Optional<Item> itemByName = itemRepository.findById(name);
     return itemByName.orElseThrow(
-        () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No job exists with id " + name));
+        () ->
+            new ResponseStatusException(
+                HttpStatus.NOT_FOUND, "Item '" + name + "' does not exist."));
   }
 
   public List<Item> getAllItems() {


### PR DESCRIPTION
## Summary
- update not-found message in `ItemService` for `getItemByName`

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68429edf6c6c83268c1e36fd840652ce