### PR TITLE
Rename misnamed exception test

### DIFF
--- a/src/test/java/com/hinderegger/steaminventorytracker/model/PriceTest.java
+++ b/src/test/java/com/hinderegger/steaminventorytracker/model/PriceTest.java
@@ -214,7 +214,7 @@ class PriceTest {
   }
 
   @Test
-  void shouldShouldThrowPriceExceptionIfHistoryIsEmtpy() {
+  void shouldThrowPriceExceptionIfHistoryIsEmpty() {
     // Arrange
     List<Price> priceHistory = new ArrayList<>(List.of());
     Item item = new Item("Item 1", priceHistory);


### PR DESCRIPTION
## Summary
- fix typo in PriceTest method name

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_68429edf30808326ba4ddd7f9758698d